### PR TITLE
Moving Dockerfile up a folder, fixing local `azd package` build

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,18 +1,18 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["backend/", "backend/"]
 COPY ["frontend/", "frontend/"]
 COPY ["shared/", "shared/"]
 RUN dotnet restore "backend/MinimalApi.csproj"
-COPY . .
+#COPY . .
 WORKDIR "/src/backend"
 RUN dotnet build "MinimalApi.csproj" -c Release -o /app/build
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,7 +12,7 @@ COPY ["backend/", "backend/"]
 COPY ["frontend/", "frontend/"]
 COPY ["shared/", "shared/"]
 RUN dotnet restore "backend/MinimalApi.csproj"
-#COPY . .
+
 WORKDIR "/src/backend"
 RUN dotnet build "MinimalApi.csproj" -c Release -o /app/build
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -9,7 +9,7 @@ services:
     host: containerapp
     language: dotnet
     docker:
-      path: ./Dockerfile
+      path: ../Dockerfile
       context: ../
 hooks:
   postprovision:


### PR DESCRIPTION
## Purpose
- Fixes local docker build failure caused by app/* paths not found
- Fixes resulting `azd package` hang
- Adds --platform support to enable intel emulation on ARM64 

## Details

The initial symptom is `azd package` hangs on the local machine.  When I see this I consider two issues:

1. the dockerfile is full stop invalid (should AZD error out then?)
2. the arch or platform considerations do not match.  e.g. you're doing intel dockerfile build on Apple Silicon (arm64)

This file had both issues.  

The Dockerfile has a multi stage build that expects to copy these four folders/assets:
COPY ["Directory.Build.props", "."]
COPY ["backend/", "backend/"]
COPY ["frontend/", "frontend/"]
COPY ["shared/", "shared/"]

Docker build had a file/folder not found error on each line.  

The reason why is the Dockerfile was inside the backend folder, so it can't see the folders above it.  

app/

> backend/
> > Dockerfile

> frontend/
> shared/
> Directory.Build.props

It needs to be one level up so Dockerfile is a peer, and finds all the folders.  This is the fix - moving the Dockerfile:

app/
> Dockerfile
> backend/
> frontend/
> shared/
> Directory.Build.props

But once you do that change, the azure.yaml must also change to find this new Dockerfile location, and set the context path up one folder too with a `../` prepended:

```yaml
  web:
    project: ./app/backend/
    host: containerapp
    language: dotnet
    docker:
      path: ../Dockerfile
      context: ../
```

The dockerfile also had a hidden bug for arm64 machines.  The solution to that is to set the --platform arg.  This [blog post](https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/) explains the design pattern.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
docker build --pull --rm -f "app/Dockerfile" -t azuresearchopenaidemocsharp:app "app"

azd package
```

## What to Check
Verify that the following are valid
azd package success
