### PR TITLE
make ApplicationInsights optional

### DIFF
--- a/app/backend/Program.cs
+++ b/app/backend/Program.cs
@@ -52,7 +52,7 @@ else
     });
 
     // set application telemetry
-    if (GetEnvVar("APPLICATIONINSIGHTS_CONNECTION_STRING") is string appInsightsConnectionString)
+    if (GetEnvVar("APPLICATIONINSIGHTS_CONNECTION_STRING") is string appInsightsConnectionString && !string.IsNullOrEmpty(appInsightsConnectionString))
     {
         builder.Services.AddApplicationInsightsTelemetry((option) =>
         {

--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -90,7 +90,7 @@ module app '../core/host/container-app-upsert.bicep' = {
       }
       {
         name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-        value: applicationInsights.properties.ConnectionString
+        value: !empty(applicationInsightsName) ? applicationInsights.properties.ConnectionString : ''
       }
       {
         name: 'AZURE_KEY_VAULT_ENDPOINT'
@@ -133,7 +133,7 @@ module app '../core/host/container-app-upsert.bicep' = {
   }
 }
 
-resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(applicationInsightsName)) {
   name: applicationInsightsName
 }
 

--- a/infra/core/monitor/monitoring.bicep
+++ b/infra/core/monitor/monitoring.bicep
@@ -1,4 +1,5 @@
 param logAnalyticsName string
+param includeApplicationInsights bool = false
 param applicationInsightsName string
 param applicationInsightsDashboardName string
 param location string = resourceGroup().location
@@ -14,7 +15,7 @@ module logAnalytics 'loganalytics.bicep' = {
   }
 }
 
-module applicationInsights 'applicationinsights.bicep' = {
+module applicationInsights 'applicationinsights.bicep' = if (includeApplicationInsights) {
   name: 'applicationinsights'
   params: {
     name: applicationInsightsName
@@ -26,8 +27,8 @@ module applicationInsights 'applicationinsights.bicep' = {
   }
 }
 
-output applicationInsightsConnectionString string = applicationInsights.outputs.connectionString
-output applicationInsightsInstrumentationKey string = applicationInsights.outputs.instrumentationKey
-output applicationInsightsName string = applicationInsights.outputs.name
+output applicationInsightsConnectionString string = includeApplicationInsights ? applicationInsights.outputs.connectionString : ''
+output applicationInsightsInstrumentationKey string = includeApplicationInsights ? applicationInsights.outputs.instrumentationKey : ''
+output applicationInsightsName string = includeApplicationInsights ? applicationInsights.outputs.name : ''
 output logAnalyticsWorkspaceId string = logAnalytics.outputs.id
 output logAnalyticsWorkspaceName string = logAnalytics.outputs.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -134,6 +134,9 @@ param webIdentityName string = ''
 @description('Name of the web app image')
 param webImageName string = ''
 
+@description('Use Application Insights for monitoring and performance tracing')
+param useApplicationInsights bool = false
+
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 
@@ -256,24 +259,9 @@ module web './app/web.bicep' = {
     openAiEndpoint: openAi.outputs.endpoint
     openAiChatGptDeployment: chatGptDeploymentName
     openAiEmbeddingDeployment: embeddingDeploymentName
-    // serviceBinds: [ redis.outputs.serviceBind ]
     serviceBinds: []
   }
 }
-
-// this launches a redis instance inside of the ACA env
-// module redis 'core/host/container-app.bicep' = {
-//   name: 'redis'
-//   scope: resourceGroup
-//   params: {
-//     name: 'redis'
-//     location: location
-//     tags: updatedTags
-//     containerAppsEnvironmentName: containerApps.outputs.environmentName
-//     containerRegistryName: containerApps.outputs.registryName
-//     serviceType: 'redis'
-//   }
-// }
 
 // Monitor application with Azure Monitor
 module monitoring 'core/monitor/monitoring.bicep' = {
@@ -283,6 +271,7 @@ module monitoring 'core/monitor/monitoring.bicep' = {
     location: location
     tags: updatedTags
     includeDashboard: false
+    includeApplicationInsights: useApplicationInsights
     logAnalyticsName: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
     applicationInsightsName: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'
     applicationInsightsDashboardName: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName : '${abbrs.portalDashboards}${resourceToken}'

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -73,6 +73,9 @@
     },
     "webIdentityName": {
       "value": "${SERVICE_WEB_IDENTITY_NAME}"
+    },
+    "useApplicationInsights": {
+      "value": "${AZURE_USE_APPLICATION_INSIGHTS=false}"
     }
   }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Make ApplicationInsights optional

before setting `AZURE_USE_APPLICATION_INSIGHTS` to true 
![image](https://github.com/Azure-Samples/azure-search-openai-demo-csharp/assets/16876986/2a9f5b2c-3ec3-4076-966a-1ef3fc4a19ba)

after setting `AZURE_USE_APPLICATION_INSIGHTS` to true and run azd up
![image](https://github.com/Azure-Samples/azure-search-openai-demo-csharp/assets/16876986/b2b9fd97-7fc5-461e-b440-439ef54310b8)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->