### PR TITLE
Fix a bug where the vector search options were `null`

### DIFF
--- a/app/backend/Extensions/SearchClientExtensions.cs
+++ b/app/backend/Extensions/SearchClientExtensions.cs
@@ -51,6 +51,7 @@ internal static class SearchClientExtensions
                 KNearestNeighborsCount = useSemanticRanker ? 50 : top,
             };
             vectorQuery.Fields.Add("embedding");
+            searchOptions.VectorSearch = new();
             searchOptions.VectorSearch.Queries.Add(vectorQuery);
         }
 


### PR DESCRIPTION
Fix a bug where the `VectorSearch` is `null`.