### PR TITLE
Fixes Issue #217 - chat is reversed by default

### DIFF
--- a/app/frontend/Shared/MainLayout.razor.cs
+++ b/app/frontend/Shared/MainLayout.razor.cs
@@ -17,7 +17,7 @@ public sealed partial class MainLayout
 
     private bool _isReversed
     {
-        get => LocalStorage.GetItem<bool?>(StorageKeys.PrefersReversedConversationSorting) ?? true;
+        get => LocalStorage.GetItem<bool?>(StorageKeys.PrefersReversedConversationSorting) ?? false;
         set => LocalStorage.SetItem<bool>(StorageKeys.PrefersReversedConversationSorting, value);
     }
 


### PR DESCRIPTION
## Purpose
Fixes #217 - new chat messages are reversed / post at the top of the page by default.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Launch the application and post 2 chat messages in a chat channel. Notice that messages go from top to bottom now. As new chat messages are added, they're appended to the end of the chat.

Detail steps:
* Open the code in Codespaces
* run `azd up` from the root directory
* Open the URL for the deployed app, test using the above description

## What to Check
As new chat messages are posted, they are added beneath previous chat messages.