### PR TITLE
Create profanity-filter.yml

### DIFF
--- a/.github/workflows/profanity-filter.yml
+++ b/.github/workflows/profanity-filter.yml
@@ -1,0 +1,26 @@
+name: Profanity filter
+
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited, reopened]
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  apply-filter:
+    name: Apply profanity filter
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Profanity filter
+      if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'  }}
+      uses: IEvangelist/profanity-filter@main
+      id: profanity-filter
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        replacement-strategy: asterisk


### PR DESCRIPTION
Adds a profanity filter to automatically remove profane content from issues and pull requests, including their titles, bodies, and comments.

Observed self-filtered profanity in issue #273.

For more information, see [Profanity filter](https://github.com/IEvangelist/profanity-filter).