### PR TITLE
Add full-width and ideographic punctuation to text splitter

### DIFF
--- a/app/shared/Shared/Services/AzureSearchEmbedService.cs
+++ b/app/shared/Shared/Services/AzureSearchEmbedService.cs
@@ -322,8 +322,8 @@ public sealed partial class AzureSearchEmbedService(
         const int SentenceSearchLimit = 100;
         const int SectionOverlap = 100;
 
-        var sentenceEndings = new[] { '.', '!', '?' };
-        var wordBreaks = new[] { ',', ';', ':', ' ', '(', ')', '[', ']', '{', '}', '\t', '\n' };
+        var sentenceEndings = new[] { '.', '。', '．', '!', '?', '‼', '⁇', '⁈', '⁉' };
+        var wordBreaks = new[] { ',', '、', ';', ':', ' ', '(', ')', '[', ']', '{', '}', '\t', '\n' };
         var allText = string.Concat(pageMap.Select(p => p.Text));
         var length = allText.Length;
         var start = 0;


### PR DESCRIPTION
## Purpose
Better support CJK documents with ideographic and full-width unicode punctuation marks.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->