### PR TITLE
Describe openAIApiKey in more detail. Fixes #318

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -157,7 +157,7 @@ param webImageName string = ''
 @description('Use Azure OpenAI service')
 param useAOAI bool
 
-@description('OpenAI API Key, leave empty to provising new Azure OpenAI instance')
+@description('OpenAI API Key, leave empty to provision a new Azure OpenAI instance')
 param openAIApiKey string
 
 @description('OpenAI Model')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -157,7 +157,7 @@ param webImageName string = ''
 @description('Use Azure OpenAI service')
 param useAOAI bool
 
-@description('OpenAI API Key')
+@description('OpenAI API Key, leave empty to provising new Azure OpenAI instance')
 param openAIApiKey string
 
 @description('OpenAI Model')


### PR DESCRIPTION
Improve the experience when running `azd up` by providing more context on how to use the openAIApiKey parameter.

## Purpose
When following the [Deployment](https://github.com/Azure-Samples/azure-search-openai-demo-csharp?tab=readme-ov-file#deployment) instructions and running `azd up`, the user gets prompted to enter a parameter without much context:
```
? Enter a value for the 'openAIApiKey' infrastructure parameter: [? for help]
```
In #318 [FBoucher](https://github.com/FBoucher) mentioned that the parameter is optional and can be left empty. Sadly the hint doesn't say that:
```
Hint: OpenAI API Key
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
- Get the code
```
git clone https://github.com/EdwinOtten/azure-search-openai-demo-csharp.git
cd [local directory]
git checkout feature/azd-up-improve-experience
```

- Test the code
  - Follow the existing [Getting Started](https://github.com/Azure-Samples/azure-search-openai-demo-csharp?tab=readme-ov-file#getting-started) guide.

## What to Check
Verify that the following are valid:
- The hint for the openAIApiKey now says:
  - _OpenAI API Key, leave empty to provision a new Azure OpenAI instance_