### PR TITLE
Add     docker: remoteBuild: true to azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -11,6 +11,7 @@ services:
     docker:
       path: ../Dockerfile
       context: ../
+      remoteBuild: true      
   function:
     project: ./app/functions/EmbedFunctions
     host: function


### PR DESCRIPTION
## Purpose

Add to azure.yaml
```yaml
    docker:
      remoteBuild: true
```
To support the new feature to avoid the local docker instance running
As described here: https://github.com/Azure-Samples/openai-chat-vision-quickstart/pull/12/files

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->