### PR TITLE
[Feature] Add streaming ability in chat page using default SDK

### DIFF
--- a/app/SharedWebComponents/Pages/Chat.razor
+++ b/app/SharedWebComponents/Pages/Chat.razor
@@ -88,6 +88,10 @@
                                     OnClick="@OnClearChat" Disabled=@(_isReceivingResponse || _questionAndAnswerMap is { Count: 0 }) />
                         </MudTooltip>
                     </MudItem>
+                    <MudItem xs="12" Class="pa-2">
+                        <MudCheckBox @bind-Checked="_useStreaming" Label="Use streaming mode" Color="Color.Secondary" 
+                                   Disabled="@_isReceivingResponse" />
+                    </MudItem>
                 </MudGrid>
             </MudItem>
         </MudGrid>

--- a/app/SharedWebComponents/Pages/Chat.razor.cs
+++ b/app/SharedWebComponents/Pages/Chat.razor.cs
@@ -54,23 +54,15 @@ public sealed partial class Chat
 
             if (_useStreaming)
             {
-                var streamingResponse = new StringBuilder();
                 try
                 {
-                    await foreach (var chunk in await ApiClient.PostStreamingRequestAsync(request, "api/chat/stream"))
+                    await foreach (var response in await ApiClient.PostStreamingRequestAsync(request, "api/chat/stream"))
                     {
-                        streamingResponse.Append(chunk.Text);
-
                         _questionAndAnswerMap[_currentQuestion] = new ChatAppResponseOrError(
-                            new[] {
-                                new ResponseChoice(0,
-                                    new ResponseMessage("assistant", streamingResponse.ToString()),
-                                    null, null)
-                            },
+                            response.Choices,
                             null);
 
                         StateHasChanged();
-
                         await Task.Delay(10);
                     }
                 }

--- a/app/SharedWebComponents/Services/ApiClient.cs
+++ b/app/SharedWebComponents/Services/ApiClient.cs
@@ -136,7 +136,7 @@ public sealed class ApiClient(HttpClient httpClient)
         }
     }
 
-    public async Task<IAsyncEnumerable<ChatChunkResponse>> PostStreamingRequestAsync<TRequest>(
+    public async Task<IAsyncEnumerable<ChatAppResponse>> PostStreamingRequestAsync<TRequest>(
         TRequest request, string apiRoute) where TRequest : ApproachRequest
     {
         var json = JsonSerializer.Serialize(
@@ -150,7 +150,7 @@ public sealed class ApiClient(HttpClient httpClient)
         
         if (response.IsSuccessStatusCode)
         {
-            return response.Content.ReadFromJsonAsAsyncEnumerable<ChatChunkResponse>();
+            return response.Content.ReadFromJsonAsAsyncEnumerable<ChatAppResponse>();
         }
         
         throw new HttpRequestException($"HTTP {(int)response.StatusCode} : {response.ReasonPhrase ?? "Unknown error"}");

--- a/app/SharedWebComponents/Services/ApiClient.cs
+++ b/app/SharedWebComponents/Services/ApiClient.cs
@@ -92,8 +92,6 @@ public sealed class ApiClient(HttpClient httpClient)
 
     public Task<AnswerResult<ChatRequest>> ChatConversationAsync(ChatRequest request) => PostRequestAsync(request, "api/chat");
 
-    public Task<AnswerResult<ChatRequest>> ChatConversationStreamingAsync(ChatRequest request) => PostRequestAsync(request, "api/chat/stream");
-
     private async Task<AnswerResult<TRequest>> PostRequestAsync<TRequest>(
         TRequest request, string apiRoute) where TRequest : ApproachRequest
     {
@@ -140,19 +138,20 @@ public sealed class ApiClient(HttpClient httpClient)
         TRequest request, string apiRoute) where TRequest : ApproachRequest
     {
         var json = JsonSerializer.Serialize(
-            request, 
+            request,
             SerializerOptions.Default);
 
         using var body = new StringContent(
             json, Encoding.UTF8, "application/json");
 
         var response = await httpClient.PostAsync(apiRoute, body);
-        
+
         if (response.IsSuccessStatusCode)
         {
-            return response.Content.ReadFromJsonAsAsyncEnumerable<ChatAppResponse>();
+            var nullableResponses = response.Content.ReadFromJsonAsAsyncEnumerable<ChatAppResponse>();
+            return nullableResponses.Where(r => r != null)!;
         }
-        
+
         throw new HttpRequestException($"HTTP {(int)response.StatusCode} : {response.ReasonPhrase ?? "Unknown error"}");
     }
 }

--- a/app/backend/Extensions/WebApplicationExtensions.cs
+++ b/app/backend/Extensions/WebApplicationExtensions.cs
@@ -89,7 +89,7 @@ internal static class WebApplicationExtensions
         return Results.BadRequest();
     }
 
-    private static async IAsyncEnumerable<ChatChunkResponse> OnPostChatStreamingAsync(
+    private static async IAsyncEnumerable<ChatAppResponse> OnPostChatStreamingAsync(
         ChatRequest request,
         ReadRetrieveReadChatService chatService,
         [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -99,12 +99,12 @@ internal static class WebApplicationExtensions
             yield break;
         }
 
-        await foreach (var chunk in chatService.ReplyStreamingAsync(
+        await foreach (var response in chatService.ReplyStreamingAsync(
             request.History,
             request.Overrides,
             cancellationToken))
         {
-            yield return new ChatChunkResponse(chunk.Length, chunk.Text);
+            yield return response;
         }
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Currently, on the Chat page, when we ask a question, the system gathers all information (e.g., answer, thought, supportingContent, etc.) and responds to the client through the API.
* We are adding streaming capability. Whenever the LLM responds with an answer in a streaming format.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
azd up
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->